### PR TITLE
Added categories to backend

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,6 +12,7 @@ rocket = "0.4.5"
 rocket_contrib = { version = "0.4.5", features = ["json", "diesel_postgres_pool"] }
 rocket_cors = "0.5.1"
 diesel = { version = "1.4.5", features = ["postgres", "uuidv07", "chrono", "serde_json"] }
+diesel-derive-enum = { version = "1", features = ["postgres"] }
 dotenv = "0.15.0"
 serde = "1.0.115"
 serde_json = "1.0.57"

--- a/backend/migrations/2022-07-05-130712_categories/up.sql
+++ b/backend/migrations/2022-07-05-130712_categories/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE projects
+ADD category VARCHAR(255) NOT NULL DEFAULT 'Other';

--- a/backend/src/api.rs
+++ b/backend/src/api.rs
@@ -493,6 +493,7 @@ pub fn submit_project(
             "votes": project.count_votes(&conn),
             "zids": project.get_zids(&conn),
             "names": project.get_names(&conn),
+            "category": project.category,
         },
     }))
 }
@@ -585,6 +586,7 @@ pub fn edit_project(user: User, project_data: Json<EditProjectData>, conn: Conn)
             "votes": project.count_votes(&conn),
             "zids": project.get_zids(&conn),
             "names": project.get_names(&conn),
+            "cateogry": project.category,
         },
     }))
 }

--- a/backend/src/catchers.rs
+++ b/backend/src/catchers.rs
@@ -1,6 +1,9 @@
 use rocket::catch;
 
-use crate::responses::{bad_request, forbidden, internal_server_error, not_found, service_unavailable, unauthorized, APIResponse};
+use crate::responses::{
+    bad_request, forbidden, internal_server_error, not_found, service_unavailable, unauthorized,
+    APIResponse,
+};
 
 #[catch(400)]
 pub fn bad_request_catcher() -> APIResponse {

--- a/backend/src/cors.rs
+++ b/backend/src/cors.rs
@@ -3,12 +3,13 @@ use rocket_cors::{AllowedOrigins, Cors, CorsOptions};
 
 pub fn cors() -> Cors {
     CorsOptions::default()
-    .allowed_origins(AllowedOrigins::all())
-    .allowed_methods(vec![Method::Get, Method::Post]
-    .into_iter()
-    .map(From::from)
-    .collect(),
-    )
-    .to_cors()
-    .expect("Failed to create CORS")
+        .allowed_origins(AllowedOrigins::all())
+        .allowed_methods(
+            vec![Method::Get, Method::Post]
+                .into_iter()
+                .map(From::from)
+                .collect(),
+        )
+        .to_cors()
+        .expect("Failed to create CORS")
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -5,18 +5,17 @@ extern crate diesel;
 #[macro_use]
 extern crate rocket;
 
-use std::env;
 use dotenv::dotenv;
 use rocket::{catchers, routes};
+use std::env;
 
 pub mod api;
+pub mod catchers;
 pub mod cors;
 pub mod database;
-pub mod catchers;
 pub mod models;
 pub mod responses;
 pub mod schema;
-
 
 /// Constructs a new Rocket instance.
 ///
@@ -24,25 +23,29 @@ pub mod schema;
 pub fn rocket_factory(database_url: &str) -> rocket::Rocket {
     rocket::ignite()
         .manage(database::init_pool(database_url))
-        .mount("/api", routes![
-            api::projects,
-            api::user,
-            api::generate_verification,
-            api::use_verification,
-            api::login,
-            api::logout,
-            api::change_name,
-            api::change_password,
-            api::generate_reset,
-            api::use_reset,
-            api::vote,
-            api::unvote,
-            api::check_zid,
-            api::submit_project,
-            api::edit_project,
-            api::delete_project,
-            api::deadlines,
-        ])
+        .mount(
+            "/api",
+            routes![
+                api::projects,
+                api::all_projects,
+                api::user,
+                api::generate_verification,
+                api::use_verification,
+                api::login,
+                api::logout,
+                api::change_name,
+                api::change_password,
+                api::generate_reset,
+                api::use_reset,
+                api::vote,
+                api::unvote,
+                api::check_zid,
+                api::submit_project,
+                api::edit_project,
+                api::delete_project,
+                api::deadlines,
+            ],
+        )
         .register(catchers![
             catchers::bad_request_catcher,
             catchers::unauthorized_catcher,
@@ -67,6 +70,5 @@ fn main() {
     // VOTE_END
 
     let database_url = env::var("DATABASE_URL").expect("DATABASE_URL must be set in env");
-    rocket_factory(&database_url)
-        .launch();
+    rocket_factory(&database_url).launch();
 }

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -1,23 +1,23 @@
-use std::env;
-use rocket::request::{self, FromRequest, Request};
-use rocket::http::Status;
-use rocket::Outcome;
-use diesel::prelude::*;
-use diesel::pg::PgConnection;
-use uuid::Uuid;
-use chrono::NaiveDateTime;
-use rand::{Rng, thread_rng};
-use rand::distributions::Alphanumeric;
 use argon2rs::argon2i_simple;
+use chrono::NaiveDateTime;
+use diesel::pg::PgConnection;
+use diesel::prelude::*;
+use rand::distributions::Alphanumeric;
+use rand::{thread_rng, Rng};
+use rocket::http::Status;
+use rocket::request::{self, FromRequest, Request};
+use rocket::Outcome;
+use std::env;
+use uuid::Uuid;
 
 use crate::database::Conn;
-use crate::schema::{projects, users, tokens, verifications, resets, votes};
 use crate::schema::projects::dsl::projects as all_projects;
-use crate::schema::users::dsl::users as all_users;
-use crate::schema::tokens::dsl::tokens as all_tokens;
-use crate::schema::verifications::dsl::verifications as all_verifications;
 use crate::schema::resets::dsl::resets as all_resets;
+use crate::schema::tokens::dsl::tokens as all_tokens;
+use crate::schema::users::dsl::users as all_users;
+use crate::schema::verifications::dsl::verifications as all_verifications;
 use crate::schema::votes::dsl::votes as all_votes;
+use crate::schema::{projects, resets, tokens, users, verifications, votes, Category};
 
 #[derive(Queryable)]
 pub struct Project {
@@ -29,7 +29,9 @@ pub struct Project {
     pub link: String,
     pub repo: String,
     pub firstyear: bool,
-    pub postgrad: bool,}
+    pub postgrad: bool,
+    pub category: Category,
+}
 
 #[derive(Insertable)]
 #[table_name = "projects"]
@@ -40,11 +42,20 @@ pub struct NewProject {
     pub repo: String,
     pub firstyear: bool,
     pub postgrad: bool,
+    pub category: Category,
 }
 
 impl Project {
     pub fn get_all(conn: &PgConnection) -> Vec<Project> {
         all_projects
+            .order(projects::id.desc())
+            .load::<Project>(conn)
+            .unwrap_or_else(|_| Vec::new())
+    }
+
+    pub fn get_category(conn: &PgConnection, cat: Category) -> Vec<Project> {
+        all_projects
+            .filter(projects::category.eq(cat))
             .order(projects::id.desc())
             .load::<Project>(conn)
             .unwrap_or_else(|_| Vec::new())
@@ -82,7 +93,16 @@ impl Project {
             .unwrap_or(0)
     }
 
-    pub fn insert(title: &str, summary: &str, link: &str, repo: &str, firstyear: bool, postgrad: bool, conn: &PgConnection) -> Option<Project> {
+    pub fn insert(
+        title: &str,
+        summary: &str,
+        link: &str,
+        repo: &str,
+        firstyear: bool,
+        postgrad: bool,
+        category: Category,
+        conn: &PgConnection,
+    ) -> Option<Project> {
         let new_project = NewProject {
             title: title.to_string(),
             summary: summary.to_string(),
@@ -90,16 +110,28 @@ impl Project {
             repo: repo.to_string(),
             firstyear,
             postgrad,
+            category,
         };
         match diesel::insert_into(projects::table)
             .values(&new_project)
-            .get_result(conn) {
-                Ok(project) => Some(project),
-                Err(_) => None,
-            }
+            .get_result(conn)
+        {
+            Ok(project) => Some(project),
+            Err(_) => None,
+        }
     }
 
-    pub fn edit(id: &Uuid, title: &str, summary: &str, link: &str, repo: &str, firstyear: bool, postgrad: bool, conn: &PgConnection) -> Option<Project> {
+    pub fn edit(
+        id: &Uuid,
+        title: &str,
+        summary: &str,
+        link: &str,
+        repo: &str,
+        firstyear: bool,
+        postgrad: bool,
+        category: Category,
+        conn: &PgConnection,
+    ) -> Option<Project> {
         match diesel::update(projects::table.find(id))
             .set((
                 projects::title.eq(title),
@@ -108,11 +140,13 @@ impl Project {
                 projects::link.eq(link),
                 projects::firstyear.eq(firstyear),
                 projects::postgrad.eq(postgrad),
+                projects::category.eq(category),
             ))
-            .get_result(conn) {
-                Ok(project) => Some(project),
-                Err(_) => None,
-            }
+            .get_result(conn)
+        {
+            Ok(project) => Some(project),
+            Err(_) => None,
+        }
     }
 
     pub fn delete(id: &Uuid, conn: &PgConnection) -> bool {
@@ -130,7 +164,7 @@ pub struct User {
     pub zid: String,
     pub name: String,
     pub password_hash: Vec<u8>,
-    pub project_id: Option<Uuid>
+    pub project_id: Option<Uuid>,
 }
 
 #[derive(Insertable)]
@@ -147,7 +181,7 @@ impl User {
         let password_salt = env::var("PASSWORD_SALT").expect("PASSWORD_SALT must be set in env");
         argon2i_simple(password, &password_salt).to_vec()
     }
-    
+
     /// Verify that `candidate_password` matches the stored password.
     pub fn verify_password(&self, password: &str) -> bool {
         let password_salt = env::var("PASSWORD_SALT").expect("PASSWORD_SALT must be set in env");
@@ -162,22 +196,21 @@ impl User {
     }
 
     pub fn get_by_id(id: &Uuid, conn: &PgConnection) -> Option<User> {
-        match all_users
-            .find(id)
-            .first::<User>(conn) {
-                Ok(user) => Some(user),
-                Err(_) => None,
-            }
+        match all_users.find(id).first::<User>(conn) {
+            Ok(user) => Some(user),
+            Err(_) => None,
+        }
     }
 
     pub fn zid_doing_project(zid: &str, project_id: &Uuid, conn: &PgConnection) -> bool {
         let id = match all_users
             .filter(users::zid.eq(zid))
             .select(users::project_id)
-            .first::<Option<Uuid>>(conn) {
-                Ok(id) => (id),
-                Err(_) => return false,
-            };
+            .first::<Option<Uuid>>(conn)
+        {
+            Ok(id) => (id),
+            Err(_) => return false,
+        };
 
         id == Some(*project_id)
     }
@@ -186,10 +219,11 @@ impl User {
         let id = match all_users
             .filter(users::zid.eq(zid))
             .select(users::project_id)
-            .first::<Option<Uuid>>(conn) {
-                Ok(id) => id,
-                Err(_) => return false,
-            };
+            .first::<Option<Uuid>>(conn)
+        {
+            Ok(id) => id,
+            Err(_) => return false,
+        };
 
         id == None
     }
@@ -211,15 +245,18 @@ impl User {
     }
 
     pub fn get_by_zid(zid: &str, conn: &PgConnection) -> Option<User> {
-        match all_users
-            .filter(users::zid.eq(zid))
-            .first::<User>(conn) {
-                Ok(user) => Some(user),
-                Err(_) => None,
-            }
+        match all_users.filter(users::zid.eq(zid)).first::<User>(conn) {
+            Ok(user) => Some(user),
+            Err(_) => None,
+        }
     }
 
-    pub fn insert(zid: &str, name: &str, password_hash: &[u8], conn: &PgConnection) -> Option<User> {
+    pub fn insert(
+        zid: &str,
+        name: &str,
+        password_hash: &[u8],
+        conn: &PgConnection,
+    ) -> Option<User> {
         let new_user = NewUser {
             zid: zid.to_string(),
             name: name.to_string(),
@@ -228,10 +265,11 @@ impl User {
 
         match diesel::insert_into(users::table)
             .values(&new_user)
-            .get_result(conn) {
-                Ok(user) => Some(user),
-                Err(_) => None,
-            }
+            .get_result(conn)
+        {
+            Ok(user) => Some(user),
+            Err(_) => None,
+        }
     }
 
     pub fn generate_token(&self, conn: &PgConnection) -> Option<Token> {
@@ -242,15 +280,16 @@ impl User {
 
         let new_token = NewToken {
             token,
-            user_id: self.id
+            user_id: self.id,
         };
 
         match diesel::insert_into(tokens::table)
             .values(&new_token)
-            .get_result(conn) {
-                Ok(token) => Some(token),
-                Err(_) => None,
-            }
+            .get_result(conn)
+        {
+            Ok(token) => Some(token),
+            Err(_) => None,
+        }
     }
 
     pub fn change_name(&self, name: &str, conn: &PgConnection) -> bool {
@@ -273,11 +312,11 @@ impl User {
         match all_users
             .find(self.id)
             .select(users::project_id)
-            .first::<Option<Uuid>>(conn) {
-                Ok(project_id) => project_id,
-                Err(_) => None,
-            }
-
+            .first::<Option<Uuid>>(conn)
+        {
+            Ok(project_id) => project_id,
+            Err(_) => None,
+        }
     }
 
     pub fn get_votes(&self, conn: &PgConnection) -> Vec<Uuid> {
@@ -299,7 +338,7 @@ impl User {
     pub fn vote(&self, project_id: &Uuid, conn: &PgConnection) -> bool {
         let vote = NewVote {
             user_id: self.id,
-            project_id: *project_id
+            project_id: *project_id,
         };
 
         diesel::insert_into(votes::table)
@@ -359,16 +398,15 @@ impl Token {
     pub fn get_by_token(token: &str, conn: &PgConnection) -> Option<Token> {
         match all_tokens
             .filter(tokens::token.eq(token))
-            .first::<Token>(conn) {
-                Ok(token) => Some(token),
-                Err(_) => None,
-            }
+            .first::<Token>(conn)
+        {
+            Ok(token) => Some(token),
+            Err(_) => None,
+        }
     }
 
     pub fn get_user(&self, conn: &PgConnection) -> Option<User> {
-        match all_users
-            .find(self.user_id)
-            .first::<User>(conn) {
+        match all_users.find(self.user_id).first::<User>(conn) {
             Ok(user) => Some(user),
             Err(_) => None,
         }
@@ -421,7 +459,12 @@ pub struct NewVerification {
 }
 
 impl Verification {
-    pub fn insert(zid: &str, name: &str, password: &str, conn: &PgConnection) -> Option<Verification> {
+    pub fn insert(
+        zid: &str,
+        name: &str,
+        password: &str,
+        conn: &PgConnection,
+    ) -> Option<Verification> {
         let token = thread_rng()
             .sample_iter(&Alphanumeric)
             .take(32)
@@ -438,10 +481,11 @@ impl Verification {
 
         match diesel::insert_into(verifications::table)
             .values(&new_verification)
-            .get_result(conn) {
-                Ok(verification) => Some(verification),
-                Err(_error) => None,
-            }
+            .get_result(conn)
+        {
+            Ok(verification) => Some(verification),
+            Err(_error) => None,
+        }
     }
 
     pub fn delete(&self, conn: &PgConnection) -> bool {
@@ -453,7 +497,8 @@ impl Verification {
     pub fn get_by_token(token: &str, conn: &PgConnection) -> Option<Verification> {
         match all_verifications
             .filter(verifications::token.eq(token))
-            .first::<Verification>(conn) {
+            .first::<Verification>(conn)
+        {
             Ok(verification) => Some(verification),
             Err(_) => None,
         }
@@ -487,7 +532,7 @@ impl Reset {
             .sample_iter(&Alphanumeric)
             .take(32)
             .collect::<String>();
-        
+
         let new_reset = NewReset {
             token,
             user_id: user.id,
@@ -495,10 +540,11 @@ impl Reset {
 
         match diesel::insert_into(resets::table)
             .values(&new_reset)
-            .get_result(conn) {
-                Ok(reset) => Some(reset),
-                Err(_) => None,
-            }
+            .get_result(conn)
+        {
+            Ok(reset) => Some(reset),
+            Err(_) => None,
+        }
     }
 
     pub fn delete(&self, conn: &PgConnection) -> bool {
@@ -509,17 +555,16 @@ impl Reset {
 
     pub fn get_by_token(token: &str, conn: &PgConnection) -> Option<Reset> {
         match all_resets
-        .filter(resets::token.eq(token))
-            .first::<Reset>(conn) {
+            .filter(resets::token.eq(token))
+            .first::<Reset>(conn)
+        {
             Ok(reset) => Some(reset),
             Err(_) => None,
         }
     }
 
     pub fn get_user(&self, conn: &PgConnection) -> Option<User> {
-        match all_users
-            .find(self.user_id)
-            .first::<User>(conn) {
+        match all_users.find(self.user_id).first::<User>(conn) {
             Ok(user) => Some(user),
             Err(_) => None,
         }
@@ -548,6 +593,7 @@ impl Vote {
             .filter(votes::project_id.eq(project_id))
             .count()
             .get_result(conn)
-            .unwrap_or(0) > 0
+            .unwrap_or(0)
+            > 0
     }
 }

--- a/backend/src/schema.rs
+++ b/backend/src/schema.rs
@@ -1,4 +1,19 @@
+use diesel_derive_enum::DbEnum;
+use rocket::request::FromFormValue;
+use serde_derive::Deserialize;
+
+#[derive(DbEnum, Debug, Clone, Copy, FromFormValue, Deserialize)]
+#[DbValueStyle = "PascalCase"]
+pub enum Category {
+    Web,
+    Mobile,
+    Other,
+}
+
 table! {
+    use diesel::sql_types::*;
+    use super::CategoryMapping;
+
     projects (id) {
         id -> Uuid,
         created_at -> Timestamp,
@@ -9,6 +24,7 @@ table! {
         repo -> Text,
         firstyear -> Bool,
         postgrad -> Bool,
+        category -> CategoryMapping,
     }
 }
 
@@ -72,11 +88,4 @@ joinable!(users -> projects (project_id));
 joinable!(votes -> projects (project_id));
 joinable!(votes -> users (user_id));
 
-allow_tables_to_appear_in_same_query!(
-    projects,
-    resets,
-    tokens,
-    users,
-    verifications,
-    votes,
-);
+allow_tables_to_appear_in_same_query!(projects, resets, tokens, users, verifications, votes,);


### PR DESCRIPTION
/api/projects still returns all of them, /api/projects?category=[Other|Web|Mobile] returns only those.
modifying or creating projects now requires a "category" field which is one of "Other", "Web", or "Mobile".
Projects are also returned with this same field.

The backend stuff is just a rust enum so easy to extend.