### PR TITLE
debugging: submit project, delete project, submit project

### DIFF
--- a/frontend/src/components/DeleteProject.js
+++ b/frontend/src/components/DeleteProject.js
@@ -16,7 +16,7 @@ const DeleteProject = (props) => {
           zid: user.zid,
           name: user.name,
           votes: user.votes,
-          project_id: null,
+          project_id: "",
         });
       })
       .catch((error) => {

--- a/frontend/src/components/SubmissionForm.js
+++ b/frontend/src/components/SubmissionForm.js
@@ -61,7 +61,7 @@ const SubmissionForm = () => {
           zid: user.zid,
           name: user.name,
           votes: user.votes,
-          project_id: response.data.project.id,
+          project_id: response.data.project.id === null ? "" : response.data.project.id,
         });
       })
       .catch((error) => {
@@ -83,7 +83,7 @@ const SubmissionForm = () => {
       .then((response) => {
         setProjects(
           projects
-            .filter((project) => user.project_id!== null && project.id !== user.project_id)
+            .filter((project) => project.id !== user.project_id)
             .concat(response.data.project)
             .sort((a, b) => a.id > b.id)
         );

--- a/frontend/src/components/SubmissionForm.js
+++ b/frontend/src/components/SubmissionForm.js
@@ -83,7 +83,7 @@ const SubmissionForm = () => {
       .then((response) => {
         setProjects(
           projects
-            .filter((project) => project.id !== user.project_id)
+            .filter((project) => user.project_id!== null && project.id !== user.project_id)
             .concat(response.data.project)
             .sort((a, b) => a.id > b.id)
         );


### PR DESCRIPTION
deleting project causes user.project_id to be null. BUT when trying to resubmit, this causes problems because the null project_id is transfered to backend, which causes a 422 error as below. this PR has a tweak which makes user.project_id be "" upon delete, which changed the backend error message to be more informative. But it still doesn't work - the api call changed to api/edit_project instead and had an error message You have not submitted a project.. This is more informative than the undefined error message in master with the api api/submit_project. Clearly there is a reliance on null in the frontend that hasn't been fixed in the logic somewhere....

OPTIONS /api/submit_project/:
    => Error: No matching routes for OPTIONS /api/submit_project/.
    => Warning: Responding with 404 Not Found catcher.
    => CORS Fairing: Turned missing route OPTIONS /api/submit_project/ into an OPTIONS pre-flight request
    => Response succeeded.
POST /api/submit_project/ application/json:
    => Matched: POST /api/submit_project application/json (submit_project)
    => Error: Couldn't parse JSON body: Error("missing field `category`", line: 1, column: 151)
    => Outcome: Failure
    => Warning: Responding with 422 Unprocessable Entity catcher.
    => Response succeeded.```